### PR TITLE
'AlienDot' error resolved (empty event deleted)

### DIFF
--- a/Assets/Scenes/Materials/Alien.anim
+++ b/Assets/Scenes/Materials/Alien.anim
@@ -202,11 +202,4 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events:
-  - time: 0
-    functionName: 
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
+  m_Events: []

--- a/Assets/Scenes/Materials/AlienDot.controller
+++ b/Assets/Scenes/Materials/AlienDot.controller
@@ -59,13 +59,13 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -4687587782420570770}
-    m_Position: {x: 200, y: 0, z: 0}
+    m_Position: {x: 200, y: 20, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_AnyStatePosition: {x: 20, y: 30, z: 0}
   m_EntryPosition: {x: 50, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}


### PR DESCRIPTION
deleted empty event on AlienDot animation to resolve error `'AlienDot' AnimationEvent has no function name specified!`